### PR TITLE
Change module for parsing URI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: docker-{{ checksum ".circleci/config.yml" }}-{{ checksum "docker-compose.system-test.yml" }}-{{ checksum "Dockerfile.system-test" }}
+          key: docker-{{ checksum ".circleci/config.yml" }}-{{ checksum "docker-compose.system-test.yml" }}-{{ checksum "Dockerfile.system-test" }}-{{ checksum "bucky-core.gemspec" }}
       - run:
           command: |
             if [ ! -f ~/caches/images.tar ]; then
@@ -14,7 +14,7 @@ jobs:
               docker save $(docker images | awk 'NR>=2 && ! /^<none>/{print $1}') -o ~/caches/images.tar
             fi
       - save_cache:
-          key: docker-{{ checksum ".circleci/config.yml" }}-{{ checksum "docker-compose.system-test.yml" }}-{{ checksum "Dockerfile.system-test" }}
+          key: docker-{{ checksum ".circleci/config.yml" }}-{{ checksum "docker-compose.system-test.yml" }}-{{ checksum "Dockerfile.system-test" }}-{{ checksum "bucky-core.gemspec" }}
           paths: ~/caches/images.tar
   system_test:
     machine: true
@@ -22,7 +22,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: docker-{{ checksum ".circleci/config.yml" }}-{{ checksum "docker-compose.system-test.yml" }}-{{ checksum "Dockerfile.system-test" }}
+          key: docker-{{ checksum ".circleci/config.yml" }}-{{ checksum "docker-compose.system-test.yml" }}-{{ checksum "Dockerfile.system-test" }}-{{ checksum "bucky-core.gemspec" }}
       - run:
           command: docker load -q -i ~/caches/images.tar
       - run:

--- a/bucky-core.gemspec
+++ b/bucky-core.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop',        '~> 0.63'
   spec.add_development_dependency 'simplecov-console', '~> 0.4.2'
 
+  spec.add_runtime_dependency 'addressable', '~> 2.5'
   spec.add_runtime_dependency 'color_echo',         '~> 3.1'
   spec.add_runtime_dependency 'json',               '~> 2.1'
   spec.add_runtime_dependency 'nokogiri',           '~> 1.8'
@@ -47,6 +48,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'selenium-webdriver', '~> 3.4'
   spec.add_runtime_dependency 'sequel',             '~> 4.48'
   spec.add_runtime_dependency 'test-unit',          '~> 3.2'
-  spec.add_runtime_dependency 'addressable', '~> 2.5'
-
 end

--- a/bucky-core.gemspec
+++ b/bucky-core.gemspec
@@ -47,4 +47,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'selenium-webdriver', '~> 3.4'
   spec.add_runtime_dependency 'sequel',             '~> 4.48'
   spec.add_runtime_dependency 'test-unit',          '~> 3.2'
+  spec.add_runtime_dependency 'addressable', '~> 2.5'
+
 end

--- a/lib/bucky/test_equipment/verifications/status_checker.rb
+++ b/lib/bucky/test_equipment/verifications/status_checker.rb
@@ -146,7 +146,7 @@ module Bucky
         def exclude_href?(href)
           return true if href.nil?
 
-          exclude_regexps = [/^javascript.+/, /^tel:\d.+/, /^mailto:.+/]
+          exclude_regexps = [/^javascript.+/i, /^tel:\d.+/i, /^mailto:.+/i]
           exclude_regexps.keep_if { |reg| reg.match?(href) }
           return true unless exclude_regexps.empty?
 

--- a/lib/bucky/utils/requests.rb
+++ b/lib/bucky/utils/requests.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'net/http'
-require 'uri'
+require 'addressable/uri'
 
 module Bucky
   module Utils
@@ -17,7 +17,7 @@ module Bucky
       # @param  [Integer/Float] read_timeout max wait time until recieve response
       # @return [Net::HTTP]         HttpStatusCode
       def get_response(uri, device, open_timeout, read_timeout)
-        parsed_uri = URI.parse(uri.to_str.strip)
+        parsed_uri = Addressable::URI.parse(uri.to_str.strip)
         query = parsed_uri.query ? "?#{parsed_uri.query}" : ''
         # If path is empty, add "/" e.g) http://example.com
         path = parsed_uri.path.empty? ? '/' : parsed_uri.path

--- a/spec/test_equipment/verifications/status_checker_spec.rb
+++ b/spec/test_equipment/verifications/status_checker_spec.rb
@@ -119,29 +119,38 @@ describe Bucky::TestEquipment::Verifications::StatusChecker do
       let(:only_same_fqdn) { true }
       context 'there is javascript:void' do
         let(:entity) do
-          '<a href="https://example.com"></a>
-          <a href="javascript:void(0)"></a>'
+          '<a href="https://example.com">link</a>
+          <a href="javascript:void(0)">link</a>
+          <a href="JavaScript:void(0)">link</a>'
         end
-        it 'exclude javascript:void' do
-          expect(subject).not_to include('javascript:void(0)')
+        ['javascript:void(0)', 'JavaScript:void(0)'].each do |expression|
+          it "exclude #{expression}" do
+            expect(subject).not_to include(expression)
+          end
         end
       end
       context 'there is tel:(number)' do
         let(:entity) do
           '<a href="https://example.com"></a>
-          <a href="tel:03-2222-2222"></a>'
+          <a href="tel:03-2222-2222"></a>
+          <a href="Tel:03-2222-2222"></a>'
         end
-        it 'exclude tel:(number)' do
-          expect(subject).not_to include('tel:03-2222-2222')
+        ['tel:03-2222-2222', 'Tel:03-2222-2222'].each do |expression|
+          it "exclude #{expression}" do
+            expect(subject).not_to include(expression)
+          end
         end
       end
       context 'there is mailto:' do
         let(:entity) do
           '<a href="https://example.com"></a>
-          <a href="mailto:hoge@hoge.com"></a>'
+          <a href="mailto:hoge@hoge.com"></a>
+          <a href="Mailto:hoge@hoge.com"></a>'
         end
-        it 'exclude mailto:' do
-          expect(subject).not_to include('mailto:hoge@hoge.com')
+        ['mailto:hoge@hoge.com', 'Mailto:hoge@hoge.com'].each do |expression|
+          it "exclude #{expression}" do
+            expect(subject).not_to include(expression)
+          end
         end
       end
       context 'relative path' do

--- a/spec/tools/lint_spec.rb
+++ b/spec/tools/lint_spec.rb
@@ -59,15 +59,15 @@ describe Bucky::Tools::Lint do
 
   describe '#diff_arr' do
     it 'return diff array' do
-      arr1 = ['k1', 'k2-k3', 'k4-k5-k6', 'k4-k5-k7']
-      arr2 = ['k1', 'k2-k3']
-      expect(lint.send(:diff_arr, arr1, arr2)).to eq ['k4-k5-k6', 'k4-k5-k7']
+      arr1 = %w[k1 k2-k3 k4-k5-k6 k4-k5-k7]
+      arr2 = %w[k1 k2-k3]
+      expect(lint.send(:diff_arr, arr1, arr2)).to eq %w[k4-k5-k6 k4-k5-k7]
     end
   end
 
   describe '#make_key_chain' do
     it 'return array containing elements of chain case' do
-      expected_list = ['k1', 'k2-k3', 'k4-k5-k6', 'k4-k5-k7']
+      expected_list = %w[k1 k2-k3 k4-k5-k6 k4-k5-k7]
       expect(lint.send(:make_key_chain, data_double)).to eq expected_list
     end
   end

--- a/spec/utils/requests_spec.rb
+++ b/spec/utils/requests_spec.rb
@@ -22,7 +22,7 @@ describe Bucky::Utils::Requests do
         subject.get_response(uri, device, open_timeout, read_timeout)
       end
     end
-    context 'Invalid URI is given' do
+    context 'Unusual URI is given' do
       ['https://example.com/path/query[]=1/', 'http://例.com?query=[]'].each do |uri|
         it "#{uri} is given, call Net::HTTP.get" do
           allow(Net::HTTP).to receive(:start).and_yield(http)

--- a/spec/utils/requests_spec.rb
+++ b/spec/utils/requests_spec.rb
@@ -12,12 +12,26 @@ describe Bucky::Utils::Requests do
   let(:http) { Net::HTTP.new('test') }
 
   describe '#get_response' do
-    it 'call Net::HTTP.get' do
-      allow(Net::HTTP).to receive(:start).and_yield(http)
-      Net::HTTP.start do |http|
-        expect(http).to receive(:get)
+    context 'Valid URL is given' do
+      let(:uri) { 'http://example.com' }
+      it 'call Net::HTTP.get' do
+        allow(Net::HTTP).to receive(:start).and_yield(http)
+        Net::HTTP.start do |http|
+          expect(http).to receive(:get)
+        end
+        subject.get_response(uri, device, open_timeout, read_timeout)
       end
-      subject.get_response(uri, device, open_timeout, read_timeout)
+    end
+    context 'Invalid URI is given' do
+      ['https://example.com/path/query[]=1/', 'http://例.com?query=[]'].each do |uri|
+        it "#{uri} is given, call Net::HTTP.get" do
+          allow(Net::HTTP).to receive(:start).and_yield(http)
+          Net::HTTP.start do |http|
+            expect(http).to receive(:get)
+          end
+          subject.get_response(uri, device, open_timeout, read_timeout)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
If an invalid URL is given, the function of 'link status check' does not work fine.

Example of invalid URL:  `http://example.com/path/?a=[]`
