### PR TITLE
Feature/add exit handler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bucky-core (0.9.15)
+    bucky-core (0.9.17)
       addressable (~> 2.5)
       color_echo (~> 3.1)
       json (~> 2.1)
@@ -15,16 +15,15 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
     ast (2.4.0)
     awesome_print (1.8.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     byebug (9.1.0)
-    childprocess (1.0.1)
-      rake (< 13.0)
+    childprocess (3.0.0)
     coderay (1.1.2)
     color_echo (3.1.1)
     debug_inspector (0.0.3)
@@ -50,7 +49,7 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
-    public_suffix (3.1.1)
+    public_suffix (4.0.1)
     rainbow (3.0.0)
     rake (12.3.0)
     rspec (3.7.0)
@@ -77,10 +76,10 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.6)
     ruby-mysql (2.9.14)
     ruby-progressbar (1.10.0)
-    rubyzip (1.2.3)
-    selenium-webdriver (3.142.3)
-      childprocess (>= 0.5, < 2.0)
-      rubyzip (~> 1.2, >= 1.2.2)
+    rubyzip (2.0.0)
+    selenium-webdriver (3.142.6)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sequel (4.49.0)
     simplecov (0.15.1)
       docile (~> 1.1.0)
@@ -91,7 +90,7 @@ GEM
       hirb
       simplecov
     simplecov-html (0.10.2)
-    test-unit (3.3.3)
+    test-unit (3.3.4)
       power_assert
     unicode-display_width (1.5.0)
 

--- a/exe/bucky
+++ b/exe/bucky
@@ -148,6 +148,7 @@ elsif ARGV == RERUN_COMMAND
   test_cond.each { |k, v| test_cond[k] = v.split(',') if v.instance_of?(String) }
   require_relative '../lib/bucky/core/test_core/test_manager'
   Bucky::Core::TestCore::TestManager.new(test_cond).rerun
+  Bucky::Core::TestCore::ExitHandler.instance.bucky_exit
 
 elsif ARGV == LINT_COMMAND
   $bucky_home_dir = Dir.pwd

--- a/exe/bucky
+++ b/exe/bucky
@@ -6,6 +6,7 @@ require 'optparse'
 require 'color_echo'
 require 'fileutils'
 require_relative '../lib/bucky/version'
+require_relative '../lib/bucky/core/test_core/exit_handler'
 
 # Color Settings
 CE.fg(:cyan)
@@ -135,6 +136,7 @@ if ARGV == RUN_COMMAND
   test_cond.each { |k, v| test_cond[k] = v.split(',') if v.instance_of?(String) }
   require_relative '../lib/bucky/core/test_core/test_manager'
   Bucky::Core::TestCore::TestManager.new(test_cond).run
+  Bucky::Core::TestCore::ExitHandler.bucky_exit
 
 elsif ARGV == RERUN_COMMAND
   $bucky_home_dir = Dir.pwd

--- a/exe/bucky
+++ b/exe/bucky
@@ -136,7 +136,7 @@ if ARGV == RUN_COMMAND
   test_cond.each { |k, v| test_cond[k] = v.split(',') if v.instance_of?(String) }
   require_relative '../lib/bucky/core/test_core/test_manager'
   Bucky::Core::TestCore::TestManager.new(test_cond).run
-  Bucky::Core::TestCore::ExitHandler.bucky_exit
+  Bucky::Core::TestCore::ExitHandler.instance.bucky_exit
 
 elsif ARGV == RERUN_COMMAND
   $bucky_home_dir = Dir.pwd

--- a/lib/bucky/core/test_core/exit_handler.rb
+++ b/lib/bucky/core/test_core/exit_handler.rb
@@ -17,13 +17,11 @@ module Bucky
         end
 
         def raise
-          p 'raised'
           @exit_code = 1
         end
 
         def bucky_exit
-          p @exit_code
-          # exit @exit_code
+          exit @exit_code
         end
       end
     end

--- a/lib/bucky/core/test_core/exit_handler.rb
+++ b/lib/bucky/core/test_core/exit_handler.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'singleton'
+
+module Bucky
+  module Core
+    module TestCore
+      class ExitHandler
+        include Singleton
+
+        @exit_code = 0
+
+        def self.reset
+          @exit_code = 0
+        end
+
+        def self.raise
+          @exit_code = @exit_code + 1
+        end
+
+        def self.bucky_exit
+          p @exit_code
+          # exit @exit_code
+        end
+      end
+    end
+  end
+end

--- a/lib/bucky/core/test_core/exit_handler.rb
+++ b/lib/bucky/core/test_core/exit_handler.rb
@@ -7,7 +7,6 @@ module Bucky
     module TestCore
       class ExitHandler
         include Singleton
-        attr_accessor :exit_code
 
         def initialize
           @exit_code = 0
@@ -15,6 +14,11 @@ module Bucky
 
         def reset
           @exit_code = 0
+        end
+
+        def raise
+          p 'raised'
+          @exit_code = 1
         end
 
         def bucky_exit

--- a/lib/bucky/core/test_core/exit_handler.rb
+++ b/lib/bucky/core/test_core/exit_handler.rb
@@ -7,18 +7,17 @@ module Bucky
     module TestCore
       class ExitHandler
         include Singleton
+        attr_accessor :exit_code
 
-        @exit_code = 0
-
-        def self.reset
+        def initialize
           @exit_code = 0
         end
 
-        def self.raise
-          @exit_code = @exit_code + 1
+        def reset
+          @exit_code = 0
         end
 
-        def self.bucky_exit
+        def bucky_exit
           p @exit_code
           # exit @exit_code
         end

--- a/lib/bucky/core/test_core/test_manager.rb
+++ b/lib/bucky/core/test_core/test_manager.rb
@@ -93,20 +93,18 @@ module Bucky
           e2e_parallel_num = Bucky::Utils::Config.instance[:e2e_parallel_num]
           linkstatus_parallel_num = Bucky::Utils::Config.instance[:linkstatus_parallel_num]
           tcg = Bucky::Core::TestCore::TestClassGenerator.new(@test_cond)
-
           case @test_cond[:test_category][0]
           when 'e2e' then parallel_new_worker_each(test_suite_data, e2e_parallel_num) { |data| tcg.generate_test_class(data) }
           when 'linkstatus' then
             link_status_url_log = {}
             parallel_distribute_into_workers(test_suite_data, linkstatus_parallel_num) { |data| tcg.generate_test_class(data, link_status_url_log) }
           end
+          Bucky::Core::TestCore::ExitHandler.instance.exit_code = $?.exitstatus
         end
 
         def execute_test
           @re_test_count.times do |i|
-            Bucky::Core::TestCore::ExitHandler.reset
-            Bucky::Core::TestCore::ExitHandler.raise
-            Bucky::Core::TestCore::ExitHandler.bucky_exit
+            Bucky::Core::TestCore::ExitHandler.instance.reset
             $round = i + 1
             test_suite_data = load_test_suites
             do_test_suites(test_suite_data)

--- a/lib/bucky/core/test_core/test_manager.rb
+++ b/lib/bucky/core/test_core/test_manager.rb
@@ -4,6 +4,7 @@ require 'parallel'
 require_relative '../test_core/test_case_loader'
 require_relative '../../utils/config'
 require_relative './test_class_generator'
+require_relative '../test_core/exit_handler'
 
 module Bucky
   module Core
@@ -103,6 +104,9 @@ module Bucky
 
         def execute_test
           @re_test_count.times do |i|
+            Bucky::Core::TestCore::ExitHandler.reset
+            Bucky::Core::TestCore::ExitHandler.raise
+            Bucky::Core::TestCore::ExitHandler.bucky_exit
             $round = i + 1
             test_suite_data = load_test_suites
             do_test_suites(test_suite_data)

--- a/lib/bucky/test_equipment/test_case/abst_test_case.rb
+++ b/lib/bucky/test_equipment/test_case/abst_test_case.rb
@@ -49,7 +49,7 @@ module Bucky
         def cleanup; end
 
         Test::Unit.at_exit do
-          exit 1 if @@test_fail = true
+          exit 1 if @@test_fail == true
         end
       end
     end

--- a/lib/bucky/test_equipment/test_case/abst_test_case.rb
+++ b/lib/bucky/test_equipment/test_case/abst_test_case.rb
@@ -2,13 +2,15 @@
 
 require 'test/unit'
 require_relative '../../core/test_core/test_result'
-require_relative '../../core/test_core/exit_handler'
 
 module Bucky
   module TestEquipment
     module TestCase
       class AbstTestCase < Test::Unit::TestCase
         class << self
+
+          @@test_fail = false
+
           def startup
             return if $debug
 
@@ -34,9 +36,7 @@ module Bucky
         end
 
         def teardown
-          Bucky::Core::TestCore::ExitHandler.raise
-          Bucky::Core::TestCore::ExitHandler.bucky_exit
-          # Bucky::Core::TestCore::ExitHandler.raise unless passed?
+          @@test_fail = true unless passed?
           return if $debug
 
           @@added_result_info[method_name.to_sym] = {
@@ -47,6 +47,10 @@ module Bucky
         end
 
         def cleanup; end
+
+        Test::Unit.at_exit do
+          exit 1 if @@test_fail = true
+        end
       end
     end
   end

--- a/lib/bucky/test_equipment/test_case/abst_test_case.rb
+++ b/lib/bucky/test_equipment/test_case/abst_test_case.rb
@@ -9,7 +9,7 @@ module Bucky
       class AbstTestCase < Test::Unit::TestCase
         class << self
 
-          @@test_fail = false
+          @@test_case_fail = false
 
           def startup
             return if $debug
@@ -36,7 +36,7 @@ module Bucky
         end
 
         def teardown
-          @@test_fail = true unless passed?
+          @@test_case_fail = true unless passed?
           return if $debug
 
           @@added_result_info[method_name.to_sym] = {
@@ -49,7 +49,7 @@ module Bucky
         def cleanup; end
 
         Test::Unit.at_exit do
-          exit 1 if @@test_fail == true
+          exit 1 if @@test_case_fail == true
         end
       end
     end

--- a/lib/bucky/test_equipment/test_case/abst_test_case.rb
+++ b/lib/bucky/test_equipment/test_case/abst_test_case.rb
@@ -2,6 +2,7 @@
 
 require 'test/unit'
 require_relative '../../core/test_core/test_result'
+require_relative '../../core/test_core/exit_handler'
 
 module Bucky
   module TestEquipment
@@ -33,6 +34,9 @@ module Bucky
         end
 
         def teardown
+          Bucky::Core::TestCore::ExitHandler.raise
+          Bucky::Core::TestCore::ExitHandler.bucky_exit
+          # Bucky::Core::TestCore::ExitHandler.raise unless passed?
           return if $debug
 
           @@added_result_info[method_name.to_sym] = {

--- a/spec/core/test_core/exit_handler_spec.rb
+++ b/spec/core/test_core/exit_handler_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative '../../../lib/bucky/core/test_core/exit_handler'
+
+describe Bucky::Core::TestCore::ExitHandler do
+  let(:instance) { Bucky::Core::TestCore::ExitHandler.instance }
+
+  describe '#initialize' do
+    it 'initialize exit handler' do
+      expect(instance.instance_variable_get(:@exit_code)).to eq 0
+    end
+  end
+
+  describe '#reset' do
+    it 'reset exit_code to 0' do
+      instance.instance_variable_set(:@exit_code, 1)
+      instance.reset
+      expect(instance.instance_variable_get(:@exit_code)).to eq 0
+    end
+  end
+
+  describe '#raise' do
+    it 'raise exit code to 1' do
+      instance.raise
+      expect(instance.instance_variable_get(:@exit_code)).to eq 1
+    end
+  end
+
+  describe '#bucky_exit' do
+    it "the exit value should be 1" do
+      begin
+        instance.instance_variable_set(:@exit_code, 1)
+        instance.bucky_exit
+      rescue SystemExit=>e
+        expect(e.status).to eq(1)
+      end
+    end
+
+    it "the exit value should be 0" do
+      begin
+        instance.instance_variable_set(:@exit_code, 0)
+        instance.bucky_exit
+      rescue SystemExit=>e
+        expect(e.status).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add exit handler to handle exit code.

Will raise exit 1 in Test::Unit::at_exit if there are some failure tests.

And get the exit in each child process in test_manager.

Rspec code has add for exit handler.