### PR TITLE
Add error handling for e2e teardown

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bucky-core (0.9.20)
+    bucky-core (0.9.21)
       addressable (~> 2.5)
       color_echo (~> 3.1)
       json (~> 2.1)

--- a/lib/bucky/test_equipment/test_case/e2e_test_case.rb
+++ b/lib/bucky/test_equipment/test_case/e2e_test_case.rb
@@ -55,8 +55,6 @@ module Bucky
 
         def teardown
           @driver.quit
-        rescue StandardError => e
-          puts e
         ensure
           super
         end

--- a/lib/bucky/test_equipment/test_case/e2e_test_case.rb
+++ b/lib/bucky/test_equipment/test_case/e2e_test_case.rb
@@ -55,6 +55,9 @@ module Bucky
 
         def teardown
           @driver.quit
+        rescue StandardError => e
+          puts e
+        ensure
           super
         end
       end


### PR DESCRIPTION
#55 

I tested using the following code.
```
# lib/bucky/test_equipment/test_case/e2e_test_case.rb
        def teardown
          # @driver.quit
          nil.quit # for test
        ensure
          super
          puts :ensure # for test
```

Outputs
```
docker exec -it bucky-core bucky run -d -D pc -c case_01
Loaded suite /usr/local/bundle/bin/bucky
Started

tag_case_01(TestCase)
  1:proc 1

:ensure
E
=====================================================================================================================================================================================
/bucky-core/lib/bucky/test_equipment/test_case/abst_test_case.rb:26:in `run'
/bucky-core/lib/bucky/test_equipment/test_case/e2e_test_case.rb:57:in `teardown'
Error: tag_case_01(Bucky::Core::TestCore::TestClasses::TestCase): NoMethodError: undefined method `quit' for nil:NilClass
=====================================================================================================================================================================================

Finished in 14.703761 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 0 assertions, 0 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.07 tests/s, 0.00 assertions/s
```