### PR TITLE
[hotfix] Add the PATH for bucky exe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk update && \
     zlib-dev
 
 ENV BC_DIR /bucky-core/
+ENV PATH /bucky-core/exe/:$PATH
 WORKDIR $BC_DIR
 COPY . $BC_DIR
 


### PR DESCRIPTION
When executing bucky-core from container it got the error bellow:
 
```
docker run --rm -it lifullsetg/bucky-core:latest bucky

Traceback (most recent call last):
	2: from /usr/local/bundle/bin/bucky:23:in `<main>'
	1: from /usr/local/lib/ruby/site_ruby/2.5.0/rubygems.rb:302:in `activate_bin_path'
/usr/local/lib/ruby/site_ruby/2.5.0/rubygems.rb:283:in `find_spec_for_exe': can't find gem bucky-core (>= 0.a) with executable bucky (Gem::GemNotFoundException)
```
Fixing it by adding bucky-core/exe to PATH for the correctness bin
