### PR TITLE
Update ruby 2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.0-alpine
+FROM ruby:2.6.10-alpine
 ENV LANG ja_JP.UTF-8
 ENV PAGER busybox less
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.8-alpine
+FROM ruby:2.6.0-alpine
 ENV LANG ja_JP.UTF-8
 ENV PAGER busybox less
 
@@ -9,7 +9,7 @@ RUN apk update && \
     build-base \
     curl-dev \
     git \
-    iproute2-minimal \
+    iproute2 \
     libxml2-dev \
     libxslt-dev \
     linux-headers \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:2.6.0-alpine
+FROM ruby:2.6.10-alpine
 ENV LANG ja_JP.UTF-8
 ENV PAGER busybox less
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:2.5.8-alpine
+FROM ruby:2.6.0-alpine
 ENV LANG ja_JP.UTF-8
 ENV PAGER busybox less
 
@@ -8,7 +8,7 @@ RUN apk update && \
     bash \
     build-base \
     curl-dev \
-    iproute2-minimal \
+    iproute2 \
     git \
     libxml2-dev \
     libxslt-dev \

--- a/Dockerfile.system-test
+++ b/Dockerfile.system-test
@@ -1,4 +1,4 @@
-FROM ruby:2.6.0-alpine
+FROM ruby:2.6.10-alpine
 ENV LANG ja_JP.UTF-8
 ENV PAGER busybox less
 

--- a/Dockerfile.system-test
+++ b/Dockerfile.system-test
@@ -1,4 +1,4 @@
-FROM ruby:2.5.8-alpine
+FROM ruby:2.6.0-alpine
 ENV LANG ja_JP.UTF-8
 ENV PAGER busybox less
 
@@ -9,7 +9,7 @@ RUN apk update && \
   build-base \
   curl-dev \
   git \
-  iproute2-minimal \
+  iproute2 \
   libxml2-dev \
   libxslt-dev \
   linux-headers \


### PR DESCRIPTION
I caught the following error.
```
docker-compose -f docker-compose.dev.yml up --build -d
~~~
ERROR:  Error installing bucky-core:
 	The last version of public_suffix (>= 2.0.2, < 6.0) to support your Ruby & RubyGems was 4.0.7. Try installing it with `gem install public_suffix -v 4.0.7` and then running the current command again
 	public_suffix requires Ruby version >= 2.6. The current ruby version is 2.5.8.224.
```