### PR TITLE
Add escape query

### DIFF
--- a/lib/bucky/utils/requests.rb
+++ b/lib/bucky/utils/requests.rb
@@ -18,7 +18,7 @@ module Bucky
       # @return [Net::HTTP]         HttpStatusCode
       def get_response(uri, device, open_timeout, read_timeout)
         parsed_uri = Addressable::URI.parse(uri.to_str.strip)
-        query = parsed_uri.query ? "?#{parsed_uri.query}" : ''
+        query = parsed_uri.query ? "?#{CGI.escape(parsed_uri.query)}" : ''
         # If path is empty, add "/" e.g) http://example.com
         path = parsed_uri.path.empty? ? '/' : parsed_uri.path
 


### PR DESCRIPTION
I found not working linkstatus when query contains single quotes.