### PR TITLE
Accept timeout argument to avoid Selenium::WebDriver::Error::TimeoutError

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       - run:
           name: Run RuboCop on changed files
           command: |
-            git diff --name-only origin/master...HEAD -- '*.rb' | xargs bundle exec rubocop -f html --out report.html
+            git diff --name-only origin/master...HEAD -- '*.rb' | xargs -r bundle exec rubocop -f html --out report.html
       - store_artifacts:
           path: report.html
   publish_to_rubygems:

--- a/bucky-core.gemspec
+++ b/bucky-core.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'addressable', '~> 2.5'
   spec.add_runtime_dependency 'color_echo',         '~> 3.1'
   spec.add_runtime_dependency 'json',               '~> 2.3.0'
-  spec.add_runtime_dependency 'nokogiri',           '~> 1.11.1'
+  spec.add_runtime_dependency 'nokogiri',           '1.18.2'
   spec.add_runtime_dependency 'parallel',           '~> 1.11'
   spec.add_runtime_dependency 'ruby-mysql',         '~> 2.9'
   spec.add_runtime_dependency 'selenium-webdriver', '4.24'

--- a/lib/bucky/test_equipment/user_operation/user_operation_helper.rb
+++ b/lib/bucky/test_equipment/user_operation/user_operation_helper.rb
@@ -27,7 +27,7 @@ module Bucky
 
         def input(args)
           # when input successfully, return of click is nil.
-          wait_until_helper(5, 0.1, Selenium::WebDriver::Error::StaleElementReferenceError) { @pages.get_part(args).send_keys(args[:word]).nil? }
+          wait_until_helper((args || {}).fetch(:timeout, 5), 0.1, Selenium::WebDriver::Error::StaleElementReferenceError) { @pages.get_part(args).send_keys(args[:word]).nil? }
         end
 
         # Clear textbox
@@ -38,7 +38,7 @@ module Bucky
         def click(args)
           elem = @pages.get_part(args)
           # when click successfully, return of click is nil.
-          wait_until_helper(5, 0.1, Selenium::WebDriver::Error::WebDriverError) { elem.click.nil? }
+          wait_until_helper((args || {}).fetch(:timeout, 5), 0.1, Selenium::WebDriver::Error::WebDriverError) { elem.click.nil? }
         end
 
         def refresh(_)
@@ -68,7 +68,7 @@ module Bucky
 
         def switch_to_the_window(args)
           # when the window successfully switched, return of switch_to.window is nil.
-          wait_until_helper(5, 0.1, Selenium::WebDriver::Error::NoSuchWindowError) { @driver.switch_to.window(args[:window_name]).nil? }
+          wait_until_helper((args || {}).fetch(:timeout, 5), 0.1, Selenium::WebDriver::Error::NoSuchWindowError) { @driver.switch_to.window(args[:window_name]).nil? }
         end
 
         # Close window
@@ -84,7 +84,7 @@ module Bucky
         end
 
         def choose(args)
-          option = wait_until_helper(5, 0.1, Selenium::WebDriver::Error::StaleElementReferenceError) { Selenium::WebDriver::Support::Select.new(@pages.get_part(args)) }
+          option = wait_until_helper((args || {}).fetch(:timeout, 5), 0.1, Selenium::WebDriver::Error::StaleElementReferenceError) { Selenium::WebDriver::Support::Select.new(@pages.get_part(args)) }
           if args.key?(:text)
             type = :text
             selected = args[type].to_s
@@ -101,8 +101,8 @@ module Bucky
         end
 
         # Alert accept
-        def accept_alert(_)
-          alert = wait_until_helper(5, 0.1, Selenium::WebDriver::Error::NoSuchAlertError) { @driver.switch_to.alert }
+        def accept_alert(args)
+          alert = wait_until_helper((args || {}).fetch(:timeout, 5), 0.1, Selenium::WebDriver::Error::NoSuchAlertError) { @driver.switch_to.alert }
           alert.accept
         end
 

--- a/spec/test_equipment/user_operation/user_operation_helper_spec.rb
+++ b/spec/test_equipment/user_operation/user_operation_helper_spec.rb
@@ -103,6 +103,7 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
   describe '#switch_to_the_window' do
     let(:operation) { :switch_to_the_window }
     let(:args) { { window_name: 'new' } }
+    let(:args_with_timeout) { { window_name: 'new', timeout: 5 } }
     it 'call driver.swich_to_window_by_name' do
       expect(driver_double).to receive_message_chain(:switch_to, :window)
       subject.send(operation, args)
@@ -110,6 +111,10 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
     it 'call wait_until_helper' do
       expect(subject).to receive(:wait_until_helper)
       subject.send(operation, args)
+    end
+    it 'call wait_until_helper with timeout argument' do
+      expect(subject).to receive(:wait_until_helper) { |timeout, *| expect(timeout).to eq(5) }
+      subject.send(operation, args_with_timeout)
     end
   end
 
@@ -146,6 +151,7 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
   describe '#input' do
     let(:operation) { :input }
     let(:args) { { page: 'top', part: 'form', word: 'hogehoge' } }
+    let(:args_with_timeout) { { page: 'top', part: 'form', word: 'hogehoge', timeout: 5 } }
     let(:elem_double) { double('elem double') }
     it 'call part#send_keys' do
       expect(pages_double).to receive_message_chain(:get_part, :send_keys)
@@ -155,6 +161,12 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
       allow(pages_double).to receive_message_chain(:get_part, :send_keys).and_return(elem_double)
       expect(subject).to receive(:wait_until_helper)
       subject.send(operation, args)
+    end
+    it 'call wait_until_helper with timeout argument' do
+      allow(pages_double).to receive_message_chain(:get_part, :send_keys).and_return(elem_double)
+      # Verify that some of the arguments match.
+      expect(subject).to receive(:wait_until_helper) { |timeout, *| expect(timeout).to eq(5) }
+      subject.send(operation, args_with_timeout)
     end
   end
 
@@ -170,6 +182,7 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
   describe '#click' do
     let(:operation) { :click }
     let(:args) { { page: 'top', part: 'form' } }
+    let(:args_with_timeout) { { page: 'top', part: 'form', timeout: 5 } }
     let(:elem_double) { double('elem double') }
     it 'call part#click' do
       allow(pages_double).to receive(:get_part).and_return(elem_double)
@@ -187,6 +200,14 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
       expect(subject).to receive(:wait_until_helper)
       subject.send(operation, args)
     end
+
+    it 'call wait_until_helper with timeout argument' do
+      allow(pages_double).to receive(:get_part).and_return(elem_double)
+      allow(elem_double).to receive(:click)
+      # Verify that some of the arguments match.
+      expect(subject).to receive(:wait_until_helper) { |timeout, *| expect(timeout).to eq(5) }
+      subject.send(operation, args_with_timeout)
+    end
   end
 
   describe '#choose' do
@@ -195,6 +216,7 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
     let(:args_value) { { page: 'top', part: 'form', value: 1 } }
     let(:args_index) { { page: 'top', part: 'form', index: 1 } }
     let(:args_error) { { page: 'top', part: 'form', error: 1 } }
+    let(:args_text_with_timeout) { { page: 'top', part: 'form', text: 'foo', timeout: 5 } }
     let(:option_double) { double('option double') }
     let(:elem_double) { double('elem double') }
     before do
@@ -221,6 +243,12 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
       expect(subject).to receive(:wait_until_helper).and_return(option_double)
       subject.send(operation, args_text)
     end
+    it 'call wait_until_helper with timeout argument' do
+      allow(option_double).to receive(:select_by).with(:text, 'foo')
+      # Verify that some of the arguments match.
+      expect(subject).to receive(:wait_until_helper) { |timeout, *| expect(timeout).to eq(5) }.and_return(option_double)
+      subject.send(operation, args_text_with_timeout)
+    end
   end
 
   describe '#accept_alert' do
@@ -234,6 +262,13 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
       allow(driver_double).to receive_message_chain(:switch_to, :alert).and_return(alert_double)
       allow(alert_double).to receive(:accept)
       expect(subject).to receive(:wait_until_helper).and_return(alert_double)
+      subject.send(operation, nil)
+    end
+    it 'call wait_until_helper with timeout argument' do
+      allow(driver_double).to receive_message_chain(:switch_to, :alert).and_return(alert_double)
+      allow(alert_double).to receive(:accept)
+      # Verify that some of the arguments match.
+      expect(subject).to receive(:wait_until_helper) { |timeout, *| expect(timeout).to eq(5) }.and_return(alert_double)
       subject.send(operation, nil)
     end
   end

--- a/spec/test_equipment/user_operation/user_operation_helper_spec.rb
+++ b/spec/test_equipment/user_operation/user_operation_helper_spec.rb
@@ -103,7 +103,8 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
   describe '#switch_to_the_window' do
     let(:operation) { :switch_to_the_window }
     let(:args) { { window_name: 'new' } }
-    let(:args_with_timeout) { { window_name: 'new', timeout: 5 } }
+    let(:timeout_sec) { 2 }
+    let(:args_with_timeout) { { window_name: 'new', timeout: timeout_sec } }
     it 'call driver.swich_to_window_by_name' do
       expect(driver_double).to receive_message_chain(:switch_to, :window)
       subject.send(operation, args)
@@ -113,7 +114,7 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
       subject.send(operation, args)
     end
     it 'call wait_until_helper with timeout argument' do
-      expect(subject).to receive(:wait_until_helper) { |timeout, *| expect(timeout).to eq(5) }
+      expect(subject).to receive(:wait_until_helper) { |timeout, *| expect(timeout).to eq(timeout_sec) }
       subject.send(operation, args_with_timeout)
     end
   end
@@ -151,7 +152,8 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
   describe '#input' do
     let(:operation) { :input }
     let(:args) { { page: 'top', part: 'form', word: 'hogehoge' } }
-    let(:args_with_timeout) { { page: 'top', part: 'form', word: 'hogehoge', timeout: 5 } }
+    let(:timeout_sec) { 2 }
+    let(:args_with_timeout) { args.merge(timeout: timeout_sec) }
     let(:elem_double) { double('elem double') }
     it 'call part#send_keys' do
       expect(pages_double).to receive_message_chain(:get_part, :send_keys)
@@ -165,7 +167,7 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
     it 'call wait_until_helper with timeout argument' do
       allow(pages_double).to receive_message_chain(:get_part, :send_keys).and_return(elem_double)
       # Verify that some of the arguments match.
-      expect(subject).to receive(:wait_until_helper) { |timeout, *| expect(timeout).to eq(5) }
+      expect(subject).to receive(:wait_until_helper) { |timeout, *| expect(timeout).to eq(timeout_sec) }
       subject.send(operation, args_with_timeout)
     end
   end
@@ -182,7 +184,8 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
   describe '#click' do
     let(:operation) { :click }
     let(:args) { { page: 'top', part: 'form' } }
-    let(:args_with_timeout) { { page: 'top', part: 'form', timeout: 5 } }
+    let(:timeout_sec) { 2 }
+    let(:args_with_timeout) { args.merge(timeout: timeout_sec) }
     let(:elem_double) { double('elem double') }
     it 'call part#click' do
       allow(pages_double).to receive(:get_part).and_return(elem_double)
@@ -205,7 +208,7 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
       allow(pages_double).to receive(:get_part).and_return(elem_double)
       allow(elem_double).to receive(:click)
       # Verify that some of the arguments match.
-      expect(subject).to receive(:wait_until_helper) { |timeout, *| expect(timeout).to eq(5) }
+      expect(subject).to receive(:wait_until_helper) { |timeout, *| expect(timeout).to eq(timeout_sec) }
       subject.send(operation, args_with_timeout)
     end
   end
@@ -216,7 +219,8 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
     let(:args_value) { { page: 'top', part: 'form', value: 1 } }
     let(:args_index) { { page: 'top', part: 'form', index: 1 } }
     let(:args_error) { { page: 'top', part: 'form', error: 1 } }
-    let(:args_text_with_timeout) { { page: 'top', part: 'form', text: 'foo', timeout: 5 } }
+    let(:timeout_sec) { 2 }
+    let(:args_text_with_timeout) { args_text.merge(timeout: timeout_sec) }
     let(:option_double) { double('option double') }
     let(:elem_double) { double('elem double') }
     before do
@@ -246,7 +250,7 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
     it 'call wait_until_helper with timeout argument' do
       allow(option_double).to receive(:select_by).with(:text, 'foo')
       # Verify that some of the arguments match.
-      expect(subject).to receive(:wait_until_helper) { |timeout, *| expect(timeout).to eq(5) }.and_return(option_double)
+      expect(subject).to receive(:wait_until_helper) { |timeout, *| expect(timeout).to eq(timeout_sec) }.and_return(option_double)
       subject.send(operation, args_text_with_timeout)
     end
   end
@@ -254,6 +258,8 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
   describe '#accept_alert' do
     let(:operation) { :accept_alert }
     let(:alert_double) { double('alert double') }
+    let(:timeout_sec) { 2 }
+    let(:args_timeout) { { timeout: timeout_sec } }
     it 'call driver.switch_to.alert.accept' do
       expect(driver_double).to receive_message_chain(:switch_to, :alert, :accept)
       subject.send(operation, nil)
@@ -268,8 +274,8 @@ describe Bucky::TestEquipment::UserOperation::UserOperationHelper do
       allow(driver_double).to receive_message_chain(:switch_to, :alert).and_return(alert_double)
       allow(alert_double).to receive(:accept)
       # Verify that some of the arguments match.
-      expect(subject).to receive(:wait_until_helper) { |timeout, *| expect(timeout).to eq(5) }.and_return(alert_double)
-      subject.send(operation, nil)
+      expect(subject).to receive(:wait_until_helper) { |timeout, *| expect(timeout).to eq(2) }.and_return(alert_double)
+      subject.send(operation, args_timeout)
     end
   end
 

--- a/system_testing/test_bucky_project/services/service_a/pc/scenarios/e2e/pc_e2e.yml
+++ b/system_testing/test_bucky_project/services/service_a/pc/scenarios/e2e/pc_e2e.yml
@@ -17,6 +17,7 @@ cases:
           operate: click
           page: index
           part: link
+          timeout: 1
       - proc: check title
         exec:
           verify: assert_title


### PR DESCRIPTION
Currently, the wait after a click is fixed at 5 seconds, and on some pages raise Selenium::WebDriver::Error::TimeoutError.
Accept a timeout as an argument to make it configurable.