### PR TITLE
fix: Add error handling and fix sed option for linux

### DIFF
--- a/.circleci/deploy_to_rubygems.sh
+++ b/.circleci/deploy_to_rubygems.sh
@@ -1,8 +1,11 @@
+#!/bin/bash
+set -eu
+
 VERSION=$(git describe --tags | grep -o -E "([0-9]+\.){1}[0-9]+(\.[0-9]+)?" | head -n1)
 git config user.email "bucky-operator@users.noreply.github.com"
 git config user.name "bucky-operator"
 # Update version.rb
-sed -i '' -e "s/VERSION = '[0-9]\{1,\}.[0-9]\{1,\}.[0-9]\{1,\}'/VERSION = '$VERSION'/" lib/bucky/version.rb
+sed -i -e "s/VERSION = '[0-9]\+\.[0-9]\+\.[0-9]\+'/VERSION = '$VERSION'/" lib/bucky/version.rb
 git diff
 git checkout master
 git add lib/bucky/version.rb

--- a/.circleci/setup_rubygems.sh
+++ b/.circleci/setup_rubygems.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -eu
+
 mkdir ~/.gem
 echo -e "---\r\n:rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
 chmod 0600 /home/circleci/.gem/credentials


### PR DESCRIPTION
This is a fix for the following error:
https://app.circleci.com/pipelines/github/lifull-dev/bucky-core/496/workflows/cb8c679c-9f21-4ac6-8809-2db64c1171a5/jobs/1852

```bash
sed: can't read : No such file or directory
```

The original sed option seemed to work correctly on MacOS, so I fixed it.

