### PR TITLE
fix: add missing disconnect call in get_ng_test_cases_at_last_execution

### DIFF
--- a/lib/bucky/core/database/test_data_operator.rb
+++ b/lib/bucky/core/database/test_data_operator.rb
@@ -89,6 +89,7 @@ module Bucky
               }
             end
           end
+          @connector.disconnect
           re_test_cond
         end
 


### PR DESCRIPTION
## 概要
get_ng_test_cases_at_last_executionメソッドでDB接続の切断処理が抜けていたため追加

## 問題
- get_ng_test_cases_at_last_executionメソッドのみ@connector.disconnectの呼び出しが抜けていた
- 他のパブリックメソッドは全てDB操作後にdisconnectを呼んでいる
- このメソッドは再実行時に複数回呼ばれるため、コネクションリークの可能性があった

## 変更内容
- get_ng_test_cases_at_last_executionメソッドの最後に@connector.disconnectを追加
- 他のパブリックメソッドと同様の実装に統一

## 影響範囲
- 再実行機能(bucky run -r, bucky rerun)使用時のDB接続管理
- コネクションリークの防止